### PR TITLE
Remove BOM from forecast.r

### DIFF
--- a/src/REntryScript/forecast.r
+++ b/src/REntryScript/forecast.r
@@ -1,4 +1,4 @@
-﻿library(forecast)
+library(forecast)
 library(plyr)
 library(zoo)
 


### PR DESCRIPTION
Forecasting might fail with the following error:

Calls: start_agent -> main -> source

Execution halted

2022-03-12 14:24:39,613|ERROR|29|140489466431232|stderr: Error in source(opt$scoring_module_name) :

forecast.r:1:1: unexpected input

1:

^
The root cause is typically bom characters at the beginning. This might happen in case a user does copy/paste of the forecast.r content instead of uploading it into the workspace notebooks. Please let the user to open the forecast.r file in an editor that allows to save it as utf-8 without bom (f.ex. notepad++) and reupload it to the notebooks. After that api_trigger.py needs to be run before starting demand forecasting from D365 in order to update the pipeline.