### PR TITLE
Fix wrong data type and installation issue

### DIFF
--- a/src/REntryScript/forecast.r
+++ b/src/REntryScript/forecast.r
@@ -327,11 +327,9 @@ entry_script$run <- function(minibatch) {
     if (is.null(datasetParameters$MISSING_VALUE_SUBSTITUTION)) {
         missingValueSubstitution <- 0;
     } else {
-
-        if (is.numeric(datasetParameters$MISSING_VALUE_SUBSTITUTION)) {
-            missingValueSubstitution <- as.numeric(datasetParameters$MISSING_VALUE_SUBSTITUTION)
-        }
-        else {
+        missingValueSubstitution = strtoi(datasetParameters$MISSING_VALUE_SUBSTITUTION);
+        if (is.na(missingValueSubstitution))
+        {
             missingValueSubstitution <- toupper(datasetParameters$MISSING_VALUE_SUBSTITUTION)
 
             if (is.na(match(missingValueSubstitution, MISSING_VALUE_OPTIONS))) {


### PR DESCRIPTION
Issue

There's a breaking change made in the Azureml package recently which is causing wrong data type casting and failing many customers

Fix

Correctly handle the MISSING_VALUE_SUBSTITUTION in R script (try to cast to integer first, if failed fallback to string)